### PR TITLE
Remove HTML tags when MATLAB is run without the desktop

### DIFF
--- a/matl.m
+++ b/matl.m
@@ -28,7 +28,7 @@ isMatlab = strcmp(version(indMainName).Name, 'MATLAB'); % 1 if Matlab, 0 if Octa
 verNum = version(indMainName).Version; % version number as a string
 verNum = str2double(regexp(verNum, '\.', 'split')); % version number as a vector
 
-useTags = isMatlab && (verNum(1)>7 || (verNum(1)==7 && verNum(2)>=13));
+useTags = isMatlab && (verNum(1)>7 || (verNum(1)==7 && verNum(2)>=13)) && usejava('desktop');
 if useTags
     strongBegin = '<strong>';
     strongEnd = '</strong>';


### PR DESCRIPTION
This commit ensures that the HTML tags are used only when running the java-based command window and not when the user launches MATLAB with `-nodesktop`. This is easily checked within MATLAB using `usejava('desktop')`.
