### PR TITLE
Adds full file paths to all files

### DIFF
--- a/genHelp.m
+++ b/genHelp.m
@@ -287,6 +287,6 @@ H.out = outFormatted;
 H.inOutTogether = inOutTogether;
 H.sourcePlain = sourcePlain;
 H.descrPlain = descrPlain;
-save help H
+save(fullfile(fileparts(mfilename('fullpath')), 'help.mat'), 'H')
 
 

--- a/matl.m
+++ b/matl.m
@@ -15,11 +15,13 @@ cOutFile = 'MATLc.m'; % temporary file for compiled code
  cOutFileNoExt = cOutFile(1:end-2); % same without extension. Needed to run file in old Matlab versions
  % cOutFileNoExt = regexprep(cOutFile, '\.m$', ''); % Old Octave versions
  % (before 3.8 apparently) don't recognize '\.'  as an escaped dot symbol
-funDefMasterFile = 'funDef.txt'; % function definition master file
-funDefMatFile = 'funDef.mat'; % function definition processed file
-preLitMasterFile = 'preLit.txt'; % master file that defines predefined strings with (key, value) pairs
-preLitMatFile = 'preLit.mat'; % processed file file that defines predefined strings with (key, value) pairs
-helpFile = 'help.mat';
+
+thisDir = fileparts(mfilename('fullpath'));
+funDefMasterFile = fullfile(thisDir, 'funDef.txt'); % function definition master file
+funDefMatFile = fullfile(thisDir, 'funDef.mat'); % function definition processed file
+preLitMasterFile = fullfile(thisDir, 'preLit.txt'); % master file that defines predefined strings with (key, value) pairs
+preLitMatFile = fullfile(thisDir, 'preLit.mat'); % processed file file that defines predefined strings with (key, value) pairs
+helpFile = fullfile(thisDir, 'help.mat');
 matlInputPrompt = ' > ';
 
 version = ver;

--- a/matl_compile.m
+++ b/matl_compile.m
@@ -25,7 +25,8 @@ global indStepComp C implicitInputBlock
 
 indStepComp = 4;
 
-compat_folder = 'compatibility';
+thisdir = fileparts(mfilename('fullpath'));
+compat_folder = fullfile(thisdir, 'compatibility');
 
 if verbose
     disp('  Generating compiled code')
@@ -348,7 +349,7 @@ if ~isMatlab
     for n = 1:numel(fnames)
         fname = fnames{n};
         if any(~cellfun(@isempty,strfind(C,fname))) % This may give false positives, but that's not a problem
-            fid = fopen([compat_folder filesep fname '_comp.m'], 'r');
+            fid = fopen(fullfile(compat_folder, [fname '_comp.m']), 'r');
             x = reshape(fread(fid,inf,'*char'),1,[]);
             fclose(fid);
             x = regexprep(x, '\r\n', '\n');


### PR DESCRIPTION
This allows MATL to be run from a directory other than the source directory and speeds up loading of the files to prevent searching the path for the files.
