### PR TITLE
Specifies full filepath when loading help.mat to prevent warnings on Octave

### DIFF
--- a/matl.m
+++ b/matl.m
@@ -177,7 +177,7 @@ else
     if verbose
         fprintf('Loading help file ''%s''\n', helpFile)
     end
-    load help
+    load(helpFile)
 end
 if verbose
     fprintf('  %i help entries found\n', numel(H.source))


### PR DESCRIPTION
Previously, I had updated all of the file paths with the full file paths to prevent Octave from issuing warnings when it found the files. It turns out that there was one `load help` lingering which had not been updated. This PR fixes that.