### PR TITLE
Update MATL Online links in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # MATL
 A programming language based on MATLAB/Octave and suitable for code golf.
 
-The compiler works in MATLAB R2015b or newer. Probably in older versions too, except for some specific functions. It is also compatible with Octave 4.0.0. The compiler tries to ensure consistent behaviour in both platforms. In addition, you can use it at [Try it online!](https://tio.run/#matl) and at [MATL Online](https://matl.suever.net/).
+The compiler works in MATLAB R2015b or newer. Probably in older versions too, except for some specific functions. It is also compatible with Octave 4.0.0. The compiler tries to ensure consistent behaviour in both platforms. In addition, you can use it at [Try it online!](https://tio.run/#matl) and at [MATL Online](https://matl.io).
 
 Installation: unpack the compressed file to a folder, and make that folder part of MATLAB's or Octave's search path.
 

--- a/spec/MATL_spec.tex
+++ b/spec/MATL_spec.tex
@@ -1456,7 +1456,7 @@ MATL code can be executed online in the following two awesome platforms. Many th
 \item
 \user{@Dennis}' \emph{Try It Online} platform\footnote{ \url{https://tio.run/\#matl}}. The online compiler runs on Octave. Text output is displayed normally, and graphical output is displayed (with limitations) by Octave's fancy ASCII-graph capabilities.
 \item
-\user{@Suever}'s \emph{MATL Online} interpreter\footnote{ \url{https://matl.suever.net/}}. This platform is MATL-specific and allows real-time text output, graphical output and documentation search, among other features.
+\user{@Suever}'s \emph{MATL Online} interpreter\footnote{ \url{https://matl.io}}. This platform is MATL-specific and allows real-time text output, graphical output and documentation search, among other features.
 \end{itemize}
 
 
@@ -1588,7 +1588,7 @@ and for suggesting that MATL should have a symbolic data type.
 \user{@Suever} for his help in finding several differences between Octave and MATLAB,
 % regarding the $0$ character, as well as the \matlab+max+ and \matlab+min+ functions;
 % concatenation of chars and logical doesn't work in Matlab
-and for finding a bug in MATL's extension of \matlab+reshape+, in \matl{YG} (\matlab+imshow+), and in Octave's compatibility patch for \matl{u} and \matl{Xu} (\matlab+unique+). Also for suggesting that \matl{\&} should produce a ``secondary default'' input/output specification, adapted to each function (my initial idea was to simply have it increase the number of inputs by $1$), and for his valuable help in finding the most appropriate secondary specification for each function, including a very useful script to get information from MATL answers posted in the Programming Puzzles and Code Golf site. Thanks too for his suggestion to have automatic input transposition for single-input versions of addition, multiplication and other functions, and for his suggestion which led to the name ``element-wise indexing''. And, specially, thanks for creating and maintaining the awesome \emph{MATL Online} platform\footnote{ \url{https://matl.suever.net/}}.
+and for finding a bug in MATL's extension of \matlab+reshape+, in \matl{YG} (\matlab+imshow+), and in Octave's compatibility patch for \matl{u} and \matl{Xu} (\matlab+unique+). Also for suggesting that \matl{\&} should produce a ``secondary default'' input/output specification, adapted to each function (my initial idea was to simply have it increase the number of inputs by $1$), and for his valuable help in finding the most appropriate secondary specification for each function, including a very useful script to get information from MATL answers posted in the Programming Puzzles and Code Golf site. Thanks too for his suggestion to have automatic input transposition for single-input versions of addition, multiplication and other functions, and for his suggestion which led to the name ``element-wise indexing''. And, specially, thanks for creating and maintaining the awesome \emph{MATL Online} platform\footnote{ \url{https://matl.io}}.
 % http://chat.stackoverflow.com/transcript/message/29716461#29716461
 % http://chat.stackoverflow.com/transcript/message/29717853#29717853
 % http://chat.stackoverflow.com/transcript/message/29835862#29835862


### PR DESCRIPTION
@lmendo This updates the URLs to use the new domain. I didn't regenerate the PDF file yet though