### PR TITLE
docs: Fix "run function"'s name in the spec, re-fix MATL Online link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # MATL
 A programming language based on MATLAB/Octave and suitable for code golf.
 
-The compiler works in MATLAB R2015b or newer. Probably in older versions too, except for some specific functions. It is also compatible with Octave 4.0.0. The compiler tries to ensure consistent behaviour in both platforms. In addition, you can use it at [Try it online!](https://tio.run/#matl) and at [MATL Online](https://matl.suever.net/).
+The compiler works in MATLAB R2015b or newer. Probably in older versions too, except for some specific functions. It is also compatible with Octave 4.0.0. The compiler tries to ensure consistent behaviour in both platforms. In addition, you can use it at [Try it online!](https://tio.run/#matl) and at [MATL Online](https://matl.io/).
 
 Installation: unpack the compressed file to a folder, and make that folder part of MATLAB's or Octave's search path.
 

--- a/spec/MATL_spec.tex
+++ b/spec/MATL_spec.tex
@@ -1268,7 +1268,7 @@ Lines of compiled code are stored in a cell array of strings \matlab+C+, from wh
 
 The function definition file and predefined literal file centralize all information about functions. This allows to define new functions without actually modifying the compiler code.
 
-The \parte{run function}, \matlab+matl_compile+, executes the compiled program. If an error is found, an error message is issued with a link to the MATL statement that generated the error. In debug mode it inserts breakpoints and opens relevant variables (taking advantage of MATLAB's \matlab+openvar+).
+The \parte{run function}, \matlab+matl_run+, executes the compiled program. If an error is found, an error message is issued with a link to the MATL statement that generated the error. In debug mode it inserts breakpoints and opens relevant variables (taking advantage of MATLAB's \matlab+openvar+).
 
 The \parte{help function}, \matlab+matl_help+, provides command-line help. It uses a struct array \matlab+H+ that contains help information for all MATL functions and statements. This struct array is generated from the function definition file, the predefined literal file and additional information by a \matlab+genHelp+ function, and is stored in file \matlab+help.mat+.
 


### PR DESCRIPTION
The spec mentions `matl_compile` as the "run function", seems like it should be `matl_run` there. 

The MATL Online link in the README got re-set to the old link in commit https://github.com/lmendo/MATL/commit/a7e1650405b9020fc3521b7b859b143355bdaf88 , probably by mistake. This reverts that. 

